### PR TITLE
fix: Replace console.error with proper logger in raindropTriggers

### DIFF
--- a/src/triggers/raindropTriggers.ts
+++ b/src/triggers/raindropTriggers.ts
@@ -26,7 +26,7 @@ async function getClient() {
     return client;
 }
 
-async function getRaindrops(client: OAuth2Client) {
+async function getRaindrops(client: OAuth2Client, logger?: IMastraLogger) {
     try {
         const token = await client.getToken();
         const lastExecution = getLastExecutionTime();
@@ -38,12 +38,12 @@ async function getRaindrops(client: OAuth2Client) {
         const data = await response.json();
         return data.items;
     } catch (error) {
-        console.error("Error fetching raindrops:", error);
+        logger?.error("Error fetching raindrops", { error: format(error) });
         return [];
     }
 }
 
-async function getCollections(client: OAuth2Client) {
+async function getCollections(client: OAuth2Client, logger?: IMastraLogger) {
     try {
         const token = await client.getToken();
         const response = await fetch("https://api.raindrop.io/rest/v1/collections", {
@@ -54,7 +54,7 @@ async function getCollections(client: OAuth2Client) {
         const data = await response.json();
         return data.items;
     } catch (error) {
-        console.error("Error fetching collections:", error);
+        logger?.error("Error fetching collections", { error: format(error) });
         return [];
     }
 }
@@ -105,9 +105,9 @@ async function handleWebhook(mastra: Mastra) {
     const logger = mastra.getLogger();
     try {
         const raindropClient = await getClient();
-        const raindrops = await getRaindrops(raindropClient);
+        const raindrops = await getRaindrops(raindropClient, logger);
         if (raindrops.length > 0) {
-            const collections = await getCollections(raindropClient);
+            const collections = await getCollections(raindropClient, logger);
             const collectionMap = new Map(collections.map((c: any) => [c._id, c.title]));
             const sheets = await getGoogleSheetsClient();
             const spreadsheetId = await createSpreadsheet(sheets, "Raindrop.io");


### PR DESCRIPTION
The getRaindrops and getCollections functions were using console.error instead of the Mastra logger system. This meant errors were not being properly tracked in the logging system.

Changes:
- Added optional logger parameter to getRaindrops and getCollections
- Replaced console.error calls with logger?.error calls
- Updated handleWebhook to pass logger to both functions
- Formatted error messages to match logging conventions

## Summary by Sourcery

Route Raindrop trigger logging through the shared Mastra logger instead of using direct console.error calls.

Bug Fixes:
- Ensure errors from getRaindrops and getCollections are captured by the Mastra logging system rather than being lost in console output.

Enhancements:
- Accept an optional logger in getRaindrops and getCollections and propagate it from handleWebhook to centralize error reporting for Raindrop triggers.