### PR TITLE
Fix broken raindropTriggers.ts and ensure ApiRoute import

### DIFF
--- a/src/triggers/raindropTriggers.ts
+++ b/src/triggers/raindropTriggers.ts
@@ -28,25 +28,12 @@ async function getClient() {
   return client;
 }
 
-async function getRaindrops(client: OAuth2Client, logger?: IMastraLogger) {
-    try {
-        const token = await client.getToken();
-        const lastExecution = getLastExecutionTime();
-        const response = await fetch(`https://api.raindrop.io/rest/v1/raindrops/0?search=created:>${lastExecution.toISOString()}`, {
-            headers: {
-                Authorization: `Bearer ${token.accessToken}`,
-            },
-        });
-        const data = await response.json();
-        return data.items;
-    } catch (error) {
-        logger?.error("Error fetching raindrops", { error: format(error) });
-        return [];
-async function getRaindrops() {
+async function getRaindrops(logger?: IMastraLogger) {
   try {
     const token = getToken();
     if (!token) {
-      console.error("No Raindrop token found");
+      const error = new Error("No Raindrop token found");
+      logger?.error("Error fetching raindrops", { error: format(error) });
       return [];
     }
     const lastExecution = getLastExecutionTime();
@@ -61,24 +48,18 @@ async function getRaindrops() {
     const data = await response.json();
     return data.items || [];
   } catch (error) {
-    console.error("Error fetching raindrops:", error);
+    logger?.error("Error fetching raindrops", { error: format(error) });
     return [];
   }
 }
 
-async function getCollections(client: OAuth2Client, logger?: IMastraLogger) {
-    try {
-        const token = await client.getToken();
-        const response = await fetch("https://api.raindrop.io/rest/v1/collections", {
-            headers: {
-                Authorization: `Bearer ${token.accessToken}`,
-            },
-        });
-        const data = await response.json();
-        return data.items;
-    } catch (error) {
-        logger?.error("Error fetching collections", { error: format(error) });
-        return [];
+async function getCollections(logger?: IMastraLogger) {
+  try {
+    const token = getToken();
+    if (!token) {
+      const error = new Error("No Raindrop token found");
+      logger?.error("Error fetching collections", { error: format(error) });
+      return [];
     }
     const response = await fetch(
       "https://api.raindrop.io/rest/v1/collections",
@@ -91,7 +72,7 @@ async function getCollections(client: OAuth2Client, logger?: IMastraLogger) {
     const data = await response.json();
     return data.items || [];
   } catch (error) {
-    console.error("Error fetching collections:", error);
+    logger?.error("Error fetching collections", { error: format(error) });
     return [];
   }
 }
@@ -143,30 +124,25 @@ async function addDataToSpreadsheet(
 }
 
 async function handleWebhook(mastra: Mastra) {
-    const logger = mastra.getLogger();
-    try {
-        const raindropClient = await getClient();
-        const raindrops = await getRaindrops(raindropClient, logger);
-        if (raindrops.length > 0) {
-            const collections = await getCollections(raindropClient, logger);
-            const collectionMap = new Map(collections.map((c: any) => [c._id, c.title]));
-            const sheets = await getGoogleSheetsClient();
-            const spreadsheetId = await createSpreadsheet(sheets, "Raindrop.io");
-            const data = [
-                ["DATE", "PROJECT", "TASK"],
-                ...(raindrops.map((raindrop: any) => [
-                    raindrop.created,
-                    collectionMap.get(raindrop.collection?.$id),
-                    raindrop.title,
-                ])),
-            ];
-            await addDataToSpreadsheet(sheets, spreadsheetId, data);
-        }
-        setLastExecutionTime();
-    } catch (error) {
-        logger?.error("Error handling Raindrop webhook", {
-            error: format(error),
-        });
+  const logger = mastra.getLogger();
+  try {
+    const raindrops = await getRaindrops(logger);
+    if (raindrops.length > 0) {
+      const collections = await getCollections(logger);
+      const collectionMap = new Map(
+        collections.map((c: any) => [c._id, c.title]),
+      );
+      const sheets = await getGoogleSheetsClient();
+      const spreadsheetId = await createSpreadsheet(sheets, "Raindrop.io");
+      const data = [
+        ["DATE", "PROJECT", "TASK"],
+        ...raindrops.map((raindrop: any) => [
+          raindrop.created,
+          collectionMap.get(raindrop.collection?.$id),
+          raindrop.title,
+        ]),
+      ];
+      await addDataToSpreadsheet(sheets, spreadsheetId, data);
     }
     setLastExecutionTime();
   } catch (error) {


### PR DESCRIPTION
Fixed a critical issue in `src/triggers/raindropTriggers.ts` where duplicated code blocks caused syntax errors and conflicting logic. 

The primary goal was to ensure `ApiRoute` is imported from `@mastra/core/server` instead of manually defined. The file already had the import, but the implementation was broken. I resolved the conflicts by unifying the implementation to use `getToken()` from `src/utils/tokenStore` and passing `logger` correctly.

Verified the fix using `npm run check`.

---
*PR created automatically by Jules for task [13888992336844714335](https://jules.google.com/task/13888992336844714335) started by @Cybersoulja*

## Summary by Sourcery

Bug Fixes:
- Resolve syntax and logic issues in Raindrop triggers by removing duplicated implementations and unifying token handling via the shared token store.