### PR TITLE
🔒 security: fix global state sharing for authentication tokens

### DIFF
--- a/src/triggers/raindropTriggers.ts
+++ b/src/triggers/raindropTriggers.ts
@@ -11,6 +11,7 @@ import {
   getLastExecutionTime,
   setLastExecutionTime,
 } from "../utils/lastExecution";
+import type { Context } from "hono";
 
 async function getClient() {
   if (!process.env.RAINDROP_CLIENT_ID || !process.env.RAINDROP_CLIENT_SECRET) {
@@ -28,9 +29,9 @@ async function getClient() {
   return client;
 }
 
-async function getRaindrops(logger?: IMastraLogger) {
+async function getRaindrops(c: Context, logger?: IMastraLogger) {
   try {
-    const token = getToken();
+    const token = getToken(c);
     if (!token) {
       const error = new Error("No Raindrop token found");
       logger?.error("Error fetching raindrops", { error: format(error) });
@@ -53,9 +54,9 @@ async function getRaindrops(logger?: IMastraLogger) {
   }
 }
 
-async function getCollections(logger?: IMastraLogger) {
+async function getCollections(c: Context, logger?: IMastraLogger) {
   try {
-    const token = getToken();
+    const token = getToken(c);
     if (!token) {
       const error = new Error("No Raindrop token found");
       logger?.error("Error fetching collections", { error: format(error) });
@@ -123,12 +124,12 @@ async function addDataToSpreadsheet(
   });
 }
 
-async function handleWebhook(mastra: Mastra) {
+async function handleWebhook(c: Context, mastra: Mastra) {
   const logger = mastra.getLogger();
   try {
-    const raindrops = await getRaindrops(logger);
+    const raindrops = await getRaindrops(c, logger);
     if (raindrops.length > 0) {
-      const collections = await getCollections(logger);
+      const collections = await getCollections(c, logger);
       const collectionMap = new Map(
         collections.map((c: any) => [c._id, c.title]),
       );
@@ -158,7 +159,7 @@ export function registerRaindropTrigger(): Array<ApiRoute> {
       method: "POST",
       handler: async (c) => {
         const mastra = c.get("mastra");
-        await handleWebhook(mastra);
+        await handleWebhook(c, mastra);
         return c.text("OK", 200);
       },
     }),
@@ -183,7 +184,7 @@ export function registerRaindropTrigger(): Array<ApiRoute> {
               redirectUri: `${host}/oauth/callback`,
             },
           );
-          setToken(token);
+          setToken(c, token);
           return c.text("OK", 200);
         } catch (error) {
           logger?.error("Error handling OAuth2 callback", {

--- a/src/utils/tokenStore.ts
+++ b/src/utils/tokenStore.ts
@@ -1,9 +1,9 @@
-let token: any = null;
+import type { Context } from 'hono';
 
-export function getToken() {
-  return token;
+export function getToken(c: Context) {
+  return c.get('token');
 }
 
-export function setToken(newToken: any) {
-  token = newToken;
+export function setToken(c: Context, newToken: any) {
+  c.set('token', newToken);
 }


### PR DESCRIPTION
This commit addresses a security vulnerability in `src/utils/tokenStore.ts` where the OAuth2 authentication token was stored in a global variable. This could lead to token leakage between concurrent requests in a multi-user environment.

The fix involves:
- Refactoring `getToken` and `setToken` to use Hono's request-scoped `Context` (`c.get` and `c.set`).
- Updating all call sites in `src/triggers/raindropTriggers.ts` to pass the `Context` object, ensuring that tokens are strictly isolated to individual requests.

This change eliminates the shared global state and aligns with security best practices for session and token management in server-side applications.

## Summary by Sourcery

Scope Raindrop OAuth token handling to the per-request Hono Context instead of a shared global variable to prevent cross-request token leakage.

Bug Fixes:
- Prevent sharing of Raindrop OAuth tokens across concurrent requests by storing tokens on the Hono request Context instead of a global variable.

Enhancements:
- Update Raindrop trigger handlers to propagate the Hono Context into token access and webhook processing for request-scoped authentication.